### PR TITLE
Overhaul to system used to determine which fragment is shown when going back to MainActivity

### DIFF
--- a/BobsLittleFreeLibrary/app/src/main/java/com/example/bobslittlefreelibrary/views/HomeFragment.java
+++ b/BobsLittleFreeLibrary/app/src/main/java/com/example/bobslittlefreelibrary/views/HomeFragment.java
@@ -38,7 +38,10 @@ import java.util.ArrayList;
 /**
  * This fragment is manages all the references and interactions on the home screen.
  *
- * TODO: Figure out final direction for the Requests Overview, setup functionality for profile button, fix the profile button changing size when switching between fragments
+ * TODO:
+ *     - Figure out final direction for the Requests Overview
+ *     - setup functionality for profile button
+ *     - fix the profile button changing size when switching between fragments
  *
  * All of the 'would-be' class variables are only local variables within onActivityCreated()
  * since values are only initialized once on this fragment. At no other time would they be called,
@@ -52,11 +55,10 @@ import java.util.ArrayList;
 public class HomeFragment extends Fragment {
 
     // Variables
-    FirebaseUser user = FirebaseAuth.getInstance().getCurrentUser();
-    FirebaseFirestore db = FirebaseFirestore.getInstance();
-    ArrayList<Book> listOfBooks;
-    TableLayout latestBooks;
-    TableLayout requestsOverview;
+    private FirebaseUser user;
+    private FirebaseFirestore db;
+    private TableLayout latestBooks;
+    private Button profileButton;
 
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
@@ -72,13 +74,18 @@ public class HomeFragment extends Fragment {
     @Override
     public void onActivityCreated(@Nullable Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
+        ((MainActivity)getActivity()).setLastActiveTab("HOME");
         Log.d("TEMP", "Home Fragment view has been created");
+
+        user = FirebaseAuth.getInstance().getCurrentUser();
+        db = FirebaseFirestore.getInstance();
+
         // Setup references to UI elements
         Button searchButton = getView().findViewById(R.id.home_search_button); // getView() cannot be called in onCreate() since the view isn't inflated yet (onCreate --> onCreateView() --> onActivityCreated()
-        Button profileButton = getView().findViewById(R.id.home_user_profile_button);
+        profileButton = getView().findViewById(R.id.home_user_profile_button);
         Button quickScanButton = getView().findViewById(R.id.home_quick_scan_button);
         latestBooks = getView().findViewById(R.id.latest_books_view);
-        requestsOverview = getView().findViewById(R.id.requests_overview_display);
+        TableLayout requestsOverview = getView().findViewById(R.id.requests_overview_display);
 
         // Initialize UI
         db.collection("users").document(user.getUid())
@@ -89,7 +96,6 @@ public class HomeFragment extends Fragment {
                 profileButton.setText(user.getUsername());
             }
         });
-
         // Setup listeners
         searchButton.setOnClickListener(v -> {
             Log.d("TEMP", "Search Button Pressed");
@@ -100,11 +106,11 @@ public class HomeFragment extends Fragment {
         quickScanButton.setOnClickListener(v -> Log.d("TEMP", "Quick Scan Button Pressed"));
 
         // Initialize Latest Books and setup listeners for ImageButtons
-        listOfBooks = new ArrayList<>();
+        ArrayList<Book> listOfBooks = new ArrayList<>();
         CollectionReference bookCollectionRef = db.collection("books");
 
         bookCollectionRef
-                .orderBy("dateAdded", Query.Direction.DESCENDING).limit(6)
+                .orderBy("dateAdded", Query.Direction.ASCENDING).limit(6)
                 .get()
                 .addOnCompleteListener(new OnCompleteListener<QuerySnapshot>() {
                     @Override

--- a/BobsLittleFreeLibrary/app/src/main/java/com/example/bobslittlefreelibrary/views/MainActivity.java
+++ b/BobsLittleFreeLibrary/app/src/main/java/com/example/bobslittlefreelibrary/views/MainActivity.java
@@ -20,9 +20,8 @@ import com.google.firebase.auth.FirebaseUser;
  * */
 public class MainActivity extends AppCompatActivity {
 
-    private Button formTemplateButton;
-    private Button blankTemplateButton;
-    private Button someAssetsButton;
+    private String lastActiveTab;
+    private BottomNavigationView bottomNavigationView;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -33,64 +32,15 @@ public class MainActivity extends AppCompatActivity {
         FirebaseUser user = FirebaseAuth.getInstance().getCurrentUser();
         Log.d("userEmail",user.getEmail().toString());
 
-        /*formTemplateButton = findViewById(R.id.form_template);
-        blankTemplateButton = findViewById(R.id.blank_template);
-        someAssetsButton = findViewById(R.id.some_assets);
-
-        formTemplateButton.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                Intent intent = new Intent(MainActivity.this, FormTemplateActivity.class);
-                MainActivity.this.startActivity(intent);
-            }
-        });
-
-        blankTemplateButton.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                Intent intent = new Intent(MainActivity.this, BlankTemplateActivity.class);
-                MainActivity.this.startActivity(intent);
-            }
-        });
-
-        someAssetsButton.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                Intent intent = new Intent(MainActivity.this, SomeAssetsActivity.class);
-                MainActivity.this.startActivity(intent);
-            }
-        });*/
-
         // Setup Bottom Nav view
-        BottomNavigationView bottomNavigationView = findViewById(R.id.bottom_navigation);
+        bottomNavigationView = findViewById(R.id.bottom_navigation);
         bottomNavigationView.setSelectedItemId(R.id.home_page);
         bottomNavigationView.setOnNavigationItemSelectedListener(navListener);
 
-        // Get which fragment to show in main activity
-        Bundle extras = getIntent().getExtras();
-        if (extras != null) {
-            switch (extras.getString("WHICH_FRAGMENT")) {
-                case "DASH":
-                    getSupportFragmentManager().beginTransaction().replace(R.id.fragment_container,
-                            new HomeFragment()).commit();
-                    bottomNavigationView.setSelectedItemId(R.id.home_page);
-                    break;
-                case "BOOKS":
-                    getSupportFragmentManager().beginTransaction().replace(R.id.fragment_container,
-                            new BooksFragment()).commit();
-                    bottomNavigationView.setSelectedItemId(R.id.books_page);
-                    break;
-                case "REQS":
-                    getSupportFragmentManager().beginTransaction().replace(R.id.fragment_container,
-                            new RequestsFragment()).commit();
-                    bottomNavigationView.setSelectedItemId(R.id.requests_page);
-                    break;
-            }
-        } else {
-            // Set default screen as home screen
-            getSupportFragmentManager().beginTransaction().replace(R.id.fragment_container,
-                    new HomeFragment()).commit();
-        }
+        // Set default screen as home screen
+        lastActiveTab = "HOME";
+        getSupportFragmentManager().beginTransaction().replace(R.id.fragment_container,
+                new HomeFragment()).commit();
     }
 
     // We define this listener outside the onCreate method to customize it to our fragments and set it in the OnCreate method
@@ -114,4 +64,34 @@ public class MainActivity extends AppCompatActivity {
                         selectedFragment).commit();
                 return true; // true means we select the current item, fragments would still show if this is false.
             };
+
+    @Override
+    protected void onStart() {
+        super.onStart();
+        switch (lastActiveTab) {
+            case "DASH":
+                getSupportFragmentManager().beginTransaction().replace(R.id.fragment_container,
+                        new HomeFragment()).commit();
+                bottomNavigationView.setSelectedItemId(R.id.home_page);
+                break;
+            case "BOOKS":
+                getSupportFragmentManager().beginTransaction().replace(R.id.fragment_container,
+                        new BooksFragment()).commit();
+                bottomNavigationView.setSelectedItemId(R.id.books_page);
+                break;
+            case "REQS":
+                getSupportFragmentManager().beginTransaction().replace(R.id.fragment_container,
+                        new RequestsFragment()).commit();
+                bottomNavigationView.setSelectedItemId(R.id.requests_page);
+                break;
+        }
+    }
+
+    /**
+     * Updates the value of lastActiveTab
+     * @param tabName the name of the tab to be set as last active
+     * */
+    public void setLastActiveTab(String tabName) {
+        lastActiveTab = tabName;
+    }
 }

--- a/BobsLittleFreeLibrary/app/src/main/java/com/example/bobslittlefreelibrary/views/books/BooksFragment.java
+++ b/BobsLittleFreeLibrary/app/src/main/java/com/example/bobslittlefreelibrary/views/books/BooksFragment.java
@@ -19,6 +19,7 @@ import androidx.fragment.app.Fragment;
 import com.example.bobslittlefreelibrary.controllers.CustomList;
 import com.example.bobslittlefreelibrary.R;
 import com.example.bobslittlefreelibrary.models.Book;
+import com.example.bobslittlefreelibrary.views.MainActivity;
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.Task;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
@@ -51,7 +52,6 @@ import static android.content.ContentValues.TAG;
  */
 public class BooksFragment extends Fragment{
 
-
     //Instantiate List of books and firebase variables
     ListView bookList;
     ArrayList<Book> dataList;
@@ -59,9 +59,6 @@ public class BooksFragment extends Fragment{
     ArrayAdapter<Book> bookAdapter;
     FirebaseUser user;
     FirebaseFirestore db;
-
-
-
 
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
@@ -74,7 +71,6 @@ public class BooksFragment extends Fragment{
         return inflater.inflate(R.layout.books_fragment, container, false);
     }
 
-
     /**
      * onResume is the point at which the code begins when another post-occuring
      * activity ends and returns to BooksFragment
@@ -84,16 +80,14 @@ public class BooksFragment extends Fragment{
         super.onResume();
     }
 
-
-
-
     @Override
     public void onActivityCreated(@Nullable Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
+        ((MainActivity)getActivity()).setLastActiveTab("BOOKS");
+
         bookList = getActivity().findViewById(R.id.bookList);
         dataList = new ArrayList<>();
         bookIDList = new ArrayList<>();
-
         bookAdapter = new CustomList(getContext(), dataList);
         bookList.setAdapter(bookAdapter);
 
@@ -101,15 +95,11 @@ public class BooksFragment extends Fragment{
         titleCard.setText("Books");
 
         user = FirebaseAuth.getInstance().getCurrentUser();
-
-
         db = FirebaseFirestore.getInstance();
 
-
-
-        /**
+        /*
          *  Accesses database and Uses Querying to select books where ownerID is the Users Id
-         *  Then adds them too the listview of books
+         *  Then adds them to the listview of books
          *
          * Exception handling in case the database is inaccessible
          */
@@ -121,24 +111,16 @@ public class BooksFragment extends Fragment{
                             dataList.clear();
                             for (QueryDocumentSnapshot document : Objects.requireNonNull(task.getResult())) {
                                 Log.d(TAG, document.getId() + " => " +document.getData());
-
                                 Book book = document.toObject(Book.class);
                                 dataList.add(book);
                                 bookIDList.add(document.getId());
                                 bookAdapter.notifyDataSetChanged();
-
                             }
-
                         } else {
                             Log.d(TAG, "Error getting documents: ", task.getException());
                         }
                     }
                 });
-
-
-
-
-
         //Click listener linking to AddBookActivity
         final FloatingActionButton addItemButton = getActivity().findViewById(R.id.add_Item);
         addItemButton.setOnClickListener(new View.OnClickListener() {
@@ -148,8 +130,6 @@ public class BooksFragment extends Fragment{
                 startActivity(intent);
             }
         });
-
-
         //Click listener linking to filter activity
         Button filterButton = getActivity().findViewById(R.id.filterAllButton);
         filterButton.setOnClickListener(new View.OnClickListener() {
@@ -159,8 +139,6 @@ public class BooksFragment extends Fragment{
                 //status.setText("/*Skippidi-pap-pap*/");
             }
         });
-
-
         // In event of an element of the list of books being clicked either
         // PublicBookView or MyBookView are called
         bookList.setOnItemClickListener(new AdapterView.OnItemClickListener() {

--- a/BobsLittleFreeLibrary/app/src/main/java/com/example/bobslittlefreelibrary/views/books/EditBookActivity.java
+++ b/BobsLittleFreeLibrary/app/src/main/java/com/example/bobslittlefreelibrary/views/books/EditBookActivity.java
@@ -195,6 +195,7 @@ public class EditBookActivity extends AppCompatActivity implements SelectImageFr
         intent.putExtra("BOOK", book);  // Send book to be displayed in book view activity\
         Log.d(TAG, "exitActivity: " + book.getDescription());
         startActivity(intent);
+        finish();
     }
 
     // Uploads the image file at usersImageFile

--- a/BobsLittleFreeLibrary/app/src/main/java/com/example/bobslittlefreelibrary/views/books/MyBookViewActivity.java
+++ b/BobsLittleFreeLibrary/app/src/main/java/com/example/bobslittlefreelibrary/views/books/MyBookViewActivity.java
@@ -33,7 +33,8 @@ import java.util.HashMap;
  * This activity provides a location to display all the information that pertains to a Book owned by the User
  * TODO:
  *  - Setup profile button functionality, profile button with username and link it to UserProfileView activity
- *  - Check if book is in the poss4sion of another user before allowing owner to delete it
+ *  - Check if book is in the possession of another user before allowing owner to delete it
+ *  - when coming back from EditBookActivity if the image is changed, the image in this activity doesnt update
  *
  *
  * */
@@ -145,14 +146,13 @@ public class MyBookViewActivity extends AppCompatActivity {
                 intent.putExtra("BOOK_ID", bookID);
                 intent.putExtra("BOOK", book);  // Send book to be displayed in book view activity
                 startActivity(intent);
+                finish();
             }
         });
         backButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                Intent intent = new Intent(MyBookViewActivity.this, MainActivity.class);
-                intent.putExtra("WHICH_FRAGMENT", "BOOKS");
-                startActivity(intent);
+                finish();
             }
         });
     }

--- a/BobsLittleFreeLibrary/app/src/main/java/com/example/bobslittlefreelibrary/views/books/PublicBookViewActivity.java
+++ b/BobsLittleFreeLibrary/app/src/main/java/com/example/bobslittlefreelibrary/views/books/PublicBookViewActivity.java
@@ -27,7 +27,10 @@ import com.google.firebase.firestore.FirebaseFirestore;
 
 /**
  * This activity provides a location to display all the information that pertains to a Book owned by another User
- * TODO: Setup profile button functionality, populate profile button with username and link it to UserProfileView activity, make it so that when a Book is requested, the user cannot send another request
+ * TODO:
+ *    -Setup profile button functionality
+ *    - populate profile button with username and link it to UserProfileView activity
+ *    - make it so that when a Book is requested, the user cannot send another request
  *
  * Currently, if a user leaves the activity and views it again, they will be able to press the request button and add another request to the db
  *

--- a/BobsLittleFreeLibrary/app/src/main/java/com/example/bobslittlefreelibrary/views/requests/RequestsFragment.java
+++ b/BobsLittleFreeLibrary/app/src/main/java/com/example/bobslittlefreelibrary/views/requests/RequestsFragment.java
@@ -22,6 +22,7 @@ import androidx.fragment.app.Fragment;
 import com.example.bobslittlefreelibrary.R;
 import com.example.bobslittlefreelibrary.controllers.CustomRequestsAdapter;
 import com.example.bobslittlefreelibrary.models.Request;
+import com.example.bobslittlefreelibrary.views.MainActivity;
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.Task;
 import com.google.android.material.tabs.TabLayout;
@@ -156,5 +157,11 @@ public class RequestsFragment extends Fragment {
             }
         });
 
+    }
+
+    @Override
+    public void onActivityCreated(@Nullable Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+        ((MainActivity)getActivity()).setLastActiveTab("REQS");
     }
 }


### PR DESCRIPTION
# MainActivity.java #
+ Removed commented out code for template buttons.
+ Added new lastActiveTab variable to keep track of the last tab we were at
    - instead of passing in the tab we came from in every intent
+ Moved switch statement that decides which fragment to show to onStart()
    - this gets called every time we *resume* MainActivity (i.e. press back button on book views) so it will always bring you back to the correct fragment.
+ Added setLastActiveTab() to be used to set the last active tab in the fragments
    -  in each fragment we call this line: ((MainActivity)getActivity()).setLastActiveTab( <string used to define the fragment, e.g. HOME, BOOKS, REQS>);

# MyBookViewActivity.java #
+ replaced intent called in the backButton listener with finish();
    - this will make us go back to the original MainActivity instead of making a new one
+ Added finish() after the startActivity call in the editButton listener to remove this book view activity from the stack (1 of 2 segments which prevent the infinite loop between MyBookView and EditBookView)

# HomeFragment.java #
+ Made class variables private
+ Moved around some lines of code
+ Changed query for latest books to sort in ascending order

# Other #
+ Removed lots of useless whitespace in BooksFragment.java
+ Added setLastActiveTab() calls in BooksFragment and RequestsFragment
+ Changed TODO comment formatting in book view activities
+ Updated exitActivity() in EditBookActivity.java to have finish() at the end