### PR TITLE
Api keys

### DIFF
--- a/BobsLittleFreeLibrary/app/build.gradle
+++ b/BobsLittleFreeLibrary/app/build.gradle
@@ -1,5 +1,7 @@
 apply plugin: 'com.android.application'
 apply plugin: 'com.google.gms.google-services'
+def localProperties = new Properties()
+localProperties.load(new FileInputStream(rootProject.file("local.properties")))
 
 android {
     compileSdkVersion 30
@@ -17,6 +19,9 @@ android {
     }
 
     buildTypes {
+        debug {
+            resValue("string", "BOOKS_API_KEY", localProperties['booksApiKey'])
+        }
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'

--- a/BobsLittleFreeLibrary/app/src/main/java/com/example/bobslittlefreelibrary/views/books/AddBookActivity.java
+++ b/BobsLittleFreeLibrary/app/src/main/java/com/example/bobslittlefreelibrary/views/books/AddBookActivity.java
@@ -21,6 +21,11 @@ import com.android.volley.Response;
 import com.android.volley.VolleyError;
 import com.android.volley.toolbox.JsonObjectRequest;
 import com.android.volley.toolbox.Volley;
+<<<<<<< Updated upstream
+=======
+import com.example.bobslittlefreelibrary.BuildConfig;
+import com.example.bobslittlefreelibrary.ScanFragment;
+>>>>>>> Stashed changes
 import com.example.bobslittlefreelibrary.models.Book;
 import com.example.bobslittlefreelibrary.R;
 import com.example.bobslittlefreelibrary.controllers.ScanFragment;
@@ -48,6 +53,7 @@ import org.json.JSONObject;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
+
 
 /*
  * AddBookActivity is an activity where a user can add a book to their collection. Scan book to
@@ -233,7 +239,7 @@ public class AddBookActivity extends AppCompatActivity implements ScanFragment.O
         Log.d(TAG, "onIsbnFound: " + isbn);
 
         String url = "https://www.googleapis.com/books/v1/volumes?q=ISBN:" + isbn
-                + "&key=AIzaSyA8uqm_F6NxRRpkXt0dDQ3RqkqATEmsuvM";
+                + "&key=" + getString(R.string.BOOKS_API_KEY);
         JsonObjectRequest request = new JsonObjectRequest(Request.Method.GET, url, null,
                 new Response.Listener<JSONObject>() {
                     @Override

--- a/BobsLittleFreeLibrary/app/src/main/java/com/example/bobslittlefreelibrary/views/books/AddBookActivity.java
+++ b/BobsLittleFreeLibrary/app/src/main/java/com/example/bobslittlefreelibrary/views/books/AddBookActivity.java
@@ -21,11 +21,6 @@ import com.android.volley.Response;
 import com.android.volley.VolleyError;
 import com.android.volley.toolbox.JsonObjectRequest;
 import com.android.volley.toolbox.Volley;
-<<<<<<< Updated upstream
-=======
-import com.example.bobslittlefreelibrary.BuildConfig;
-import com.example.bobslittlefreelibrary.ScanFragment;
->>>>>>> Stashed changes
 import com.example.bobslittlefreelibrary.models.Book;
 import com.example.bobslittlefreelibrary.R;
 import com.example.bobslittlefreelibrary.controllers.ScanFragment;


### PR DESCRIPTION
Moved api keys to local.properties to hide them from git tracking, see https://blog.mindorks.com/using-local-properties-file-to-avoid-api-keys-check-in-into-version-control-system